### PR TITLE
minor (bug fixes) update to global installs of ionic, @ionic/cli-plugin-proxy, and @ionic/cli-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@
 <br>
 <b>cli packages: </b>(/usr/local/lib/node_modules)<br>
 <br>
-    @ionic/cli-plugin-proxy : 1.4.12<br>
-    @ionic/cli-utils        : 1.13.0<br>
-    ionic (Ionic CLI)       : 3.13.0<br>
+    @ionic/cli-plugin-proxy : 1.4.13<br>
+    @ionic/cli-utils        : 1.13.1<br>
+    ionic (Ionic CLI)       : 3.13.1<br>
 <br>
 <b>global packages:</b><br>
 <br>


### PR DESCRIPTION
cli packages: (/usr/local/lib/node_modules)

    @ionic/cli-plugin-proxy : 1.4.13
    @ionic/cli-utils        : 1.13.1
    ionic (Ionic CLI)       : 3.13.1
