### PR TITLE
added spacer to bottom of My Groups page so that Cancel and Create Group buttons are not overlapped by the footer tab bar

### DIFF
--- a/src/pages/mygroups/mygroups.html
+++ b/src/pages/mygroups/mygroups.html
@@ -66,9 +66,10 @@
                 <ion-col>
                     <button ion-button (click)="pushGroupPage()" color="primary">Create Group</button>
                 </ion-col>
-                <ion-col></ion-col>
-            </ion-row>
+             </ion-row>
         </ion-grid>
+       <!-- force spacer so footer tab bar does not hide the Cancel and Create Group buttons -->
+       <div style="min-height: 10vh !important;"></div>
     </section>
 </ion-content>
 


### PR DESCRIPTION
added spacer to bottom of My Groups page so that Cancel and Create Group buttons are not overlapped by the footer tab bar